### PR TITLE
Use 127.0.0.1 in local URLs

### DIFF
--- a/lib/gradle/deploy/GradlePerBranchSpringBootDeploymentGoal.ts
+++ b/lib/gradle/deploy/GradlePerBranchSpringBootDeploymentGoal.ts
@@ -113,7 +113,7 @@ export function executeGradlePerBranchSpringBootDeploy(projectLoader: ProjectLoa
         lowerPort: 9090,
         successPatterns: SpringBootSuccessPatterns,
         commandLineArgumentsFor: springBootGradleArgs,
-        baseUrl: `http://${os.hostname()}`,
+        baseUrl: "http://127.0.0.1",
         maxConcurrentDeployments: 5,
         ...opts,
     };

--- a/lib/java/deploy/MavenPerBranchSpringBootDeploymentGoal.ts
+++ b/lib/java/deploy/MavenPerBranchSpringBootDeploymentGoal.ts
@@ -113,7 +113,7 @@ export function executeMavenPerBranchSpringBootDeploy(projectLoader: ProjectLoad
         lowerPort: 9090,
         successPatterns: SpringBootSuccessPatterns,
         commandLineArgumentsFor: springBootMavenArgs,
-        baseUrl: `http://${os.hostname()}`,
+        baseUrl: "http://127.0.0.1",
         maxConcurrentDeployments: 5,
         ...opts,
     };

--- a/lib/spring/deploy/localSpringBootDeployers.ts
+++ b/lib/spring/deploy/localSpringBootDeployers.ts
@@ -27,12 +27,12 @@ import { mavenDeployer } from "../../maven/deploy/mavenDeployer";
 import { SpringBootSuccessPatterns } from "../springLoggingPatterns";
 
 export function localExecutableJarDeployer(): Deployer<ManagedDeploymentTargetInfo> {
-  return executableJarDeployer({
-      baseUrl: "http://localhost",
-      lowerPort: 8082,
-      commandLineArgumentsFor: springBootExecutableJarArgs,
-      successPatterns: SpringBootSuccessPatterns,
-  });
+    return executableJarDeployer({
+        baseUrl: "http://127.0.0.1",
+        lowerPort: 8082,
+        commandLineArgumentsFor: springBootExecutableJarArgs,
+        successPatterns: SpringBootSuccessPatterns,
+    });
 }
 
 export function springBootExecutableJarArgs(si: StartupInfo): string[] {
@@ -45,7 +45,7 @@ export function springBootExecutableJarArgs(si: StartupInfo): string[] {
 
 export function mavenSourceDeployer(projectLoader: ProjectLoader): Deployer<ManagedDeploymentTargetInfo> {
     return mavenDeployer(projectLoader, {
-        baseUrl: "http://localhost",
+        baseUrl: "http://127.0.0.1",
         lowerPort: 9090,
         commandLineArgumentsFor: springBootMavenArgs,
         successPatterns: SpringBootSuccessPatterns,


### PR DESCRIPTION
Prefer 127.0.0.1 rather than localhost or os.hostname() when creating
local URLs.  It is more reliable.

Closes #61