### PR TITLE
Only use mvnw on win32 if JAVA_HOME set

### DIFF
--- a/lib/java/deploy/MavenPerBranchSpringBootDeploymentGoal.ts
+++ b/lib/java/deploy/MavenPerBranchSpringBootDeploymentGoal.ts
@@ -39,7 +39,7 @@ import * as spawn from "cross-spawn";
 import * as os from "os";
 import * as portfinder from "portfinder";
 import { MavenLogInterpreter } from "../../maven/build/mavenLogInterpreter";
-import { determineMavenCommand } from "../../maven/MavenCommand";
+import { determineMavenCommand } from "../../maven/mavenCommand";
 import { SpringBootSuccessPatterns } from "../../spring/springLoggingPatterns";
 
 export const ListBranchDeploys: CommandHandlerRegistration = {

--- a/lib/maven/build/MavenBuilder.ts
+++ b/lib/maven/build/MavenBuilder.ts
@@ -34,7 +34,7 @@ import {
     LocalBuilder,
     LocalBuildInProgress,
 } from "@atomist/sdm-core";
-import { determineMavenCommand } from "../MavenCommand";
+import { determineMavenCommand } from "../mavenCommand";
 import { MavenProjectIdentifier } from "../parse/pomParser";
 import { VersionedArtifact } from "../VersionedArtifact";
 import { MavenLogInterpreter } from "./mavenLogInterpreter";

--- a/lib/maven/build/helpers.ts
+++ b/lib/maven/build/helpers.ts
@@ -26,7 +26,7 @@ import {
 } from "@atomist/sdm";
 import { ProjectVersioner } from "@atomist/sdm-core";
 import * as df from "dateformat";
-import { determineMavenCommand } from "../MavenCommand";
+import { determineMavenCommand } from "../mavenCommand";
 import { MavenProjectIdentifier } from "../parse/pomParser";
 import { mavenPackage } from "./MavenBuilder";
 

--- a/lib/maven/deploy/mavenDeployer.ts
+++ b/lib/maven/deploy/mavenDeployer.ts
@@ -41,7 +41,7 @@ import {
     SpawnedDeployment,
 } from "@atomist/sdm-core";
 import * as spawn from "cross-spawn";
-import { determineMavenCommand } from "../MavenCommand";
+import { determineMavenCommand } from "../mavenCommand";
 
 /**
  * Managed deployments

--- a/lib/maven/mavenCommand.ts
+++ b/lib/maven/mavenCommand.ts
@@ -18,8 +18,12 @@ import { Project } from "@atomist/automation-client";
 import * as os from "os";
 
 export function determineMavenCommand(p: Project): string {
-    if (p.fileExistsSync("mvnw.cmd") && os.platform() === "win32") {
-       return "mvnw";
+    if (os.platform() === "win32") {
+        if (process.env.JAVA_HOME && p.fileExistsSync("mvnw.cmd")) {
+            return "mvnw";
+        } else {
+            return "mvn";
+        }
     } else if (p.fileExistsSync("mvnw")) {
         return "./mvnw";
     } else {


### PR DESCRIPTION
The mvnw.cmd script requires that JAVA_HOME be set, it does not try to
automatically determine it like the mvnw shell script does.  Before
returning mvnw on win32, make sure it exists _and_ JAVA_HOME is set.
Add tests for both types of platforms.

Rename file containing determineMavenCommand to mavenCommand since it
should not have a class name if it does not contain one class having
the same name.

Closes #62