### PR TITLE
Fix compilation, remove internal index imports

### DIFF
--- a/lib/java/javaProjectUtils.ts
+++ b/lib/java/javaProjectUtils.ts
@@ -21,7 +21,7 @@ import {
 } from "@atomist/automation-client";
 import { CodeTransform } from "@atomist/sdm";
 import * as _ from "lodash";
-import { SpringProjectCreationParameters } from "../..";
+import { SpringProjectCreationParameters } from "../spring/generate/SpringProjectCreationParameters";
 import { JavaProjectStructure } from "./JavaProjectStructure";
 
 export const AllJavaFiles = "**/*.java";

--- a/lib/spring/generate/springBootUtils.ts
+++ b/lib/spring/generate/springBootUtils.ts
@@ -19,10 +19,12 @@ import {
     Project,
 } from "@atomist/automation-client";
 import { CodeTransform } from "@atomist/sdm";
-import { SpringProjectCreationParameters } from "../../..";
 import { renameClass } from "../../java/javaProjectUtils";
 import { SpringBootProjectStructure } from "./SpringBootProjectStructure";
-import { computeServiceClassName } from "./SpringProjectCreationParameters";
+import {
+    computeServiceClassName,
+    SpringProjectCreationParameters,
+} from "./SpringProjectCreationParameters";
 
 /**
  * Infer the Spring Boot structure and rename the class.

--- a/lib/spring/transform/tryToUpgradeSpringBootVersion.ts
+++ b/lib/spring/transform/tryToUpgradeSpringBootVersion.ts
@@ -22,7 +22,7 @@ import {
     CodeTransformRegistration,
     TransformModeSuggestion,
 } from "@atomist/sdm";
-import { makeBuildAware } from "@atomist/sdm/lib/pack/build-aware-transform";
+import { pack } from "@atomist/sdm-core";
 import { SetSpringBootVersionTransform } from "./setSpringBootVersionTransform";
 
 @Parameters()
@@ -58,7 +58,7 @@ export class UpgradeSpringBootParameters implements TransformModeSuggestion {
  * handler to respond to the build with either a PR and Issue
  * @type {HandleCommand<EditOneOrAllParameters>}
  */
-export const TryToUpgradeSpringBootVersion: CodeTransformRegistration<UpgradeSpringBootParameters> = makeBuildAware({
+export const TryToUpgradeSpringBootVersion: CodeTransformRegistration<UpgradeSpringBootParameters> = pack.buildAware.makeBuildAware({
     transform: SetSpringBootVersionTransform,
     paramsMaker: UpgradeSpringBootParameters,
     name: "boot-upgrade",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@atomist/antlr": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@atomist/antlr/-/antlr-1.0.0.tgz",
-      "integrity": "sha512-vpzqHpV8qAHKDkF1Ayfwd/amqQCEiZy+n+bGOktERZM3+hSnQSIT5QvMGWyGCHvgO3ERA4r+OLFVL9eDh3BZ2g==",
+      "version": "1.0.1-master.20180916163028",
+      "resolved": "https://registry.npmjs.org/@atomist/antlr/-/antlr-1.0.1-master.20180916163028.tgz",
+      "integrity": "sha512-tNge932FMagpuYnygxgoKZUCfjcLlWlezjx8Mbt6zvLb/wG/HxGvCW5j2FoKuZyVjgo2r7olQ5lQT9ztuB1aNQ==",
       "requires": {
         "@types/lodash": "^4.14.116",
         "antlr4ts": "^0.4.1-alpha.0",
@@ -15,7 +15,8 @@
       }
     },
     "@atomist/automation-client": {
-      "version": "https://r.atomist.com/2069506567",
+      "version": "1.0.0-master.20180918193639",
+      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-1.0.0-master.20180918193639.tgz",
       "integrity": "sha512-PjX1psHvPoPALF43oDRVYrik/66KEBt5CvaYY6aet1Czjcr8IKwp2YBTAWddZOUxR3d/FwdCMysmcc0UM/bjgw==",
       "dev": true,
       "requires": {
@@ -121,6 +122,23 @@
         "yargs": "^12.0.1"
       },
       "dependencies": {
+        "@atomist/microgrammar": {
+          "version": "1.0.0-M.4",
+          "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-1.0.0-M.4.tgz",
+          "integrity": "sha512-HmXBEePPzXEdVEvbOwn3Dc5Pnb0LZqUzNVFq7VzuR4KO+vmej7Thm5R0eIdSjxNOzLQPWf+zYWD6D/j1YRXf7Q==",
+          "dev": true
+        },
+        "@atomist/tree-path": {
+          "version": "1.0.0-M.4",
+          "resolved": "https://registry.npmjs.org/@atomist/tree-path/-/tree-path-1.0.0-M.4.tgz",
+          "integrity": "sha512-gcSmRAfNLcD8YBKeVGEbDjWFHr8EExk0UvJ73WndJhO8e8v1xCVXCnbA1cIFxLtpcRHfWJVS/vGx1jqtkLoX4g==",
+          "dev": true,
+          "requires": {
+            "@atomist/microgrammar": "1.0.0-M.4",
+            "@types/lodash": "^4.14.116",
+            "lodash": "^4.17.10"
+          }
+        },
         "axios": {
           "version": "https://atomist.jfrog.io/atomist/npm-dev/axios/-/axios-0.17.1-proxy-fix.tgz",
           "integrity": "sha512-cqmzETbIbqN219ApegeV0UJx9FrqL9Q8zFzyqgd35E31AAgDO6IJhrVb1U+eyri4UpELl0850Y+L/TIjkHdxmg==",
@@ -134,16 +152,17 @@
       }
     },
     "@atomist/microgrammar": {
-      "version": "1.0.0-M.4",
-      "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-1.0.0-M.4.tgz",
-      "integrity": "sha512-HmXBEePPzXEdVEvbOwn3Dc5Pnb0LZqUzNVFq7VzuR4KO+vmej7Thm5R0eIdSjxNOzLQPWf+zYWD6D/j1YRXf7Q=="
+      "version": "1.0.0-master.20180916080140",
+      "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-1.0.0-master.20180916080140.tgz",
+      "integrity": "sha512-2csX4kaeqFoNdToqroiiSL8J3SyTHBXbawMBNMZPEKk29wFnYR3enOuWdaJ0RuOIKakSqc4hR4vCK2H6CyO2/w=="
     },
     "@atomist/sdm": {
-      "version": "https://r.atomist.com/3361986651",
-      "integrity": "sha512-bXtaYeRMkfBPjb3iTA4VazI1TR0oEjXTkh5efPk6dVHjmvehMLxNo5JqTt+dls27UwfGZhRL0Ii1axgWZGrBlw==",
+      "version": "1.0.0-master.20180920152437",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm/-/sdm-1.0.0-master.20180920152437.tgz",
+      "integrity": "sha512-LCLhf8MvCiliNNRQK+oadnEngkENwDGHKYeho4mU0gOtDLV3wsZwvJVqy50NhGlK9Ezo9PdFatUAO0a4r6SPKA==",
       "dev": true,
       "requires": {
-        "@atomist/slack-messages": "1.0.0",
+        "@atomist/slack-messages": "^1.0.0",
         "@types/lodash": "^4.14.116",
         "@types/node": "^10.7.1",
         "axios": "^0.18.0",
@@ -169,9 +188,9 @@
       }
     },
     "@atomist/sdm-core": {
-      "version": "1.0.0-M.4",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm-core/-/sdm-core-1.0.0-M.4.tgz",
-      "integrity": "sha512-nLOqo83bM5+16UGQTxWNPHCE8Wd+kFfT7XGNINAlpu8T6i88ElFMDAGLhCxzoIk4iw12oaF7q794WYjbNSLbzg==",
+      "version": "1.0.0-master.20180920202624",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm-core/-/sdm-core-1.0.0-master.20180920202624.tgz",
+      "integrity": "sha512-t7WYdfvcM6ZXaSdlb81MumszgNd93QUYw5R1k0P2wva9TVPmG73JBHWjqd7Lb9OEepKyy48gzOMzWaqYpR8Tpw==",
       "dev": true,
       "requires": {
         "@atomist/slack-messages": "1.0.0",
@@ -208,13 +227,20 @@
       "dev": true
     },
     "@atomist/tree-path": {
-      "version": "1.0.0-M.4",
-      "resolved": "https://registry.npmjs.org/@atomist/tree-path/-/tree-path-1.0.0-M.4.tgz",
-      "integrity": "sha512-gcSmRAfNLcD8YBKeVGEbDjWFHr8EExk0UvJ73WndJhO8e8v1xCVXCnbA1cIFxLtpcRHfWJVS/vGx1jqtkLoX4g==",
+      "version": "1.0.0-master.20180916091356",
+      "resolved": "https://registry.npmjs.org/@atomist/tree-path/-/tree-path-1.0.0-master.20180916091356.tgz",
+      "integrity": "sha512-Y0vNqnzoCAHrWTqkYT7KSTofjbz4I7/h3ou2ObOSuKploB1X0Aqefb/wUbsGCaIwdmYhoIaMlOUnhKRs39jcOA==",
       "requires": {
         "@atomist/microgrammar": "1.0.0-M.4",
         "@types/lodash": "^4.14.116",
         "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "@atomist/microgrammar": {
+          "version": "1.0.0-M.4",
+          "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-1.0.0-M.4.tgz",
+          "integrity": "sha512-HmXBEePPzXEdVEvbOwn3Dc5Pnb0LZqUzNVFq7VzuR4KO+vmej7Thm5R0eIdSjxNOzLQPWf+zYWD6D/j1YRXf7Q=="
+        }
       }
     },
     "@babel/code-frame": {
@@ -351,7 +377,8 @@
     "@typed/curry": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@typed/curry/-/curry-1.0.1.tgz",
-      "integrity": "sha1-VV1GJLDL8J4QGUUybTu5/8q6NlU="
+      "integrity": "sha1-VV1GJLDL8J4QGUUybTu5/8q6NlU=",
+      "dev": true
     },
     "@types/app-root-path": {
       "version": "1.2.4",
@@ -474,9 +501,9 @@
       }
     },
     "@types/glob": {
-      "version": "5.0.35",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
-      "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
+      "version": "5.0.36",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.36.tgz",
+      "integrity": "sha512-KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==",
       "dev": true,
       "requires": {
         "@types/events": "*",
@@ -563,9 +590,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
-      "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
+      "version": "10.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.1.tgz",
+      "integrity": "sha512-nzsx28VwfaIykfzMAG9TB3jxF5Nn+1/WMKnmVZc8TsB+LMIVvwUscVn7PAq+LFaY5ng5u4jp5mRROSswo76PPA=="
     },
     "@types/passport": {
       "version": "0.4.6",
@@ -3649,7 +3676,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -10431,9 +10458,9 @@
       }
     },
     "unbzip2-stream": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
-      "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.0.tgz",
+      "integrity": "sha512-kE2WkurNnPUMcryNioS68DDbhoPB8Qxsd8btHSj+sd5Pjh2GsjmeHLzMSqV9HHziAo8FzVxVCJl9ZYhk7yY1pA==",
       "requires": {
         "buffer": "^3.0.1",
         "through": "^2.3.6"

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "dependencies": {
-    "@atomist/antlr": "1.0.0",
-    "@atomist/microgrammar": "1.0.0-M.4",
-    "@atomist/tree-path": "1.0.0-M.4",
+    "@atomist/antlr": "1.0.1-master.20180916163028",
+    "@atomist/microgrammar": "1.0.0-master.20180916080140",
+    "@atomist/tree-path": "1.0.0-master.20180916091356",
     "@types/cross-spawn": "^6.0.0",
     "@types/dateformat": "^1.0.1",
     "@types/decompress": "^4.2.3",
@@ -50,9 +50,9 @@
     "@atomist/sdm-core": "*"
   },
   "devDependencies": {
-    "@atomist/automation-client": "https://r.atomist.com/2069506567",
-    "@atomist/sdm": "https://r.atomist.com/3361986651",
-    "@atomist/sdm-core": "1.0.0-M.4",
+    "@atomist/automation-client": "1.0.0-master.20180918193639",
+    "@atomist/sdm": "1.0.0-master.20180920152437",
+    "@atomist/sdm-core": "1.0.0-master.20180920202624",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.5.7",
     "@types/power-assert": "^1.5.0",


### PR DESCRIPTION

Fix compilation after upgrade.  Remove imports from this package's
index.ts.  Having them breaks compilation.