### PR TITLE
Update to Java 9 grammar

### DIFF
--- a/lib/java/JavaProjectStructure.ts
+++ b/lib/java/JavaProjectStructure.ts
@@ -15,7 +15,7 @@
  */
 
 import {
-    JavaFileParser,
+    Java9FileParser,
     KotlinFileParser,
 } from "@atomist/antlr";
 import {
@@ -50,7 +50,7 @@ export class JavaProjectStructure {
      */
     public static async infer(p: ProjectAsync): Promise<JavaProjectStructure> {
         // Treat Java and Kotlin as one
-        const packages = (await astUtils.findMatches(p, JavaFileParser, JavaSourceFiles, JavaPackageName))
+        const packages = (await astUtils.findMatches(p, Java9FileParser, JavaSourceFiles, JavaPackageName))
             .concat(await astUtils.findMatches(p, KotlinFileParser, KotlinSourceFiles, KotlinPackage));
         const uniquePackages = _.uniq(packages.map(pack => pack.$value));
         if (uniquePackages.length === 0) {

--- a/lib/java/query/javaPathExpressions.ts
+++ b/lib/java/query/javaPathExpressions.ts
@@ -24,7 +24,7 @@ export const JavaPackage = "//packageDeclaration";
  * Path expression using the Java grammar for a Java package declaration
  * @type {string}
  */
-export const JavaPackageName = "//packageDeclaration//qualifiedName";
+export const JavaPackageName = "//packageDeclaration/packageName";
 
 export const JavaImports = "//importDeclaration";
 

--- a/lib/java/query/javaPathExpressions.ts
+++ b/lib/java/query/javaPathExpressions.ts
@@ -20,12 +20,6 @@
  */
 export const JavaPackage = "//packageDeclaration";
 
-/**
- * Path expression using the Java grammar for a Java package declaration
- * @type {string}
- */
-export const JavaPackageName = "//packageDeclaration/packageName";
-
 export const JavaImports = "//importDeclaration";
 
 /**

--- a/lib/java/query/javaQueries.ts
+++ b/lib/java/query/javaQueries.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { JavaFileParser } from "@atomist/antlr";
+import { Java9FileParser } from "@atomist/antlr";
 import {
     astUtils,
     Project,
@@ -31,7 +31,7 @@ export async function existingAnnotations(p: Project, opts: {
     sourceFilePath: string,
     className: string,
 }): Promise<Annotation[]> {
-    return astUtils.gatherFromMatches(p, JavaFileParser, opts.sourceFilePath,
+    return astUtils.gatherFromMatches(p, Java9FileParser, opts.sourceFilePath,
         annotationsOnJavaClass(opts.className),
         toBoundedElement);
 }

--- a/lib/java/query/packageInfo.ts
+++ b/lib/java/query/packageInfo.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { JavaFileParser } from "@atomist/antlr";
+import { Java9FileParser } from "@atomist/antlr";
 import {
     astUtils,
     Project,
@@ -37,7 +37,7 @@ export interface PackageInfo extends BoundedElement {
  * @return {Promise<Import[]>}
  */
 export async function packageInfo(p: Project, path: string): Promise<PackageInfo> {
-    const packages = await astUtils.gatherFromMatches(p, JavaFileParser, path, JavaPackage, m => {
+    const packages = await astUtils.gatherFromMatches(p, Java9FileParser, path, JavaPackage, m => {
         return {
             fqn: m.$children.find(c => c.$name === "qualifiedName").$value,
             ...toBoundedElement(m),

--- a/lib/java/query/packageInfo.ts
+++ b/lib/java/query/packageInfo.ts
@@ -39,7 +39,7 @@ export interface PackageInfo extends BoundedElement {
 export async function packageInfo(p: Project, path: string): Promise<PackageInfo> {
     const packages = await astUtils.gatherFromMatches(p, Java9FileParser, path, JavaPackage, m => {
         return {
-            fqn: m.$children.find(c => c.$name === "qualifiedName").$value,
+            fqn: m.$children.find(c => c.$name === "packageName").$value,
             ...toBoundedElement(m),
         };
     });

--- a/lib/java/query/packageInfo.ts
+++ b/lib/java/query/packageInfo.ts
@@ -39,7 +39,8 @@ export interface PackageInfo extends BoundedElement {
 export async function packageInfo(p: Project, path: string): Promise<PackageInfo> {
     const packages = await astUtils.gatherFromMatches(p, Java9FileParser, path, JavaPackage, m => {
         return {
-            fqn: m.$children.find(c => c.$name === "packageName").$value,
+            // TODO this is inelegant pending recursive Antlr grammar fix
+            fqn: m.$value.replace(/.*package (.*);/, "$1"),
             ...toBoundedElement(m),
         };
     });

--- a/lib/java/transform/addAnnotationToClass.ts
+++ b/lib/java/transform/addAnnotationToClass.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { JavaFileParser } from "@atomist/antlr";
+import { Java9FileParser } from "@atomist/antlr";
 import { astUtils } from "@atomist/automation-client";
 import { CodeTransform } from "@atomist/sdm";
 import { classNameFromFqn } from "../javaProjectUtils";
@@ -37,7 +37,7 @@ export function addAnnotationToClassRaw(opts: {
         const existing = await existingAnnotations(p, opts);
         if (!existing.some(ann => ann.value.startsWith("@" + opts.annotationName))) {
             await astUtils.doWithAllMatches(p,
-                JavaFileParser,
+                Java9FileParser,
                 opts.sourceFilePath,
                 javaClassDeclarationWithName(opts.className), m => {
                     m.$value = `@${opts.annotationName}\n${m.$value}`;

--- a/lib/java/transform/imports.ts
+++ b/lib/java/transform/imports.ts
@@ -15,11 +15,18 @@
  */
 
 import { Java9FileParser } from "@atomist/antlr";
-import { astUtils, logger, Project } from "@atomist/automation-client";
+import {
+    astUtils,
+    logger,
+    Project,
+} from "@atomist/automation-client";
 import { CodeTransform } from "@atomist/sdm";
 import { evaluateScalar } from "@atomist/tree-path";
 import * as _ from "lodash";
-import { countTill, insertAt } from "../../util/formatUtils";
+import {
+    countTill,
+    insertAt,
+} from "../../util/formatUtils";
 import { classNameFromFqn } from "../javaProjectUtils";
 import { JavaImports } from "../query/javaPathExpressions";
 import { packageInfo } from "../query/packageInfo";

--- a/lib/java/transform/imports.ts
+++ b/lib/java/transform/imports.ts
@@ -15,14 +15,14 @@
  */
 
 import { Java9FileParser } from "@atomist/antlr";
-import { astUtils, logger, Project, } from "@atomist/automation-client";
+import { astUtils, logger, Project } from "@atomist/automation-client";
 import { CodeTransform } from "@atomist/sdm";
+import { evaluateScalar } from "@atomist/tree-path";
 import * as _ from "lodash";
 import { countTill, insertAt } from "../../util/formatUtils";
 import { classNameFromFqn } from "../javaProjectUtils";
 import { JavaImports } from "../query/javaPathExpressions";
 import { packageInfo } from "../query/packageInfo";
-import { evaluateScalar } from "@atomist/tree-path";
 
 export interface Import {
 

--- a/lib/java/transform/imports.ts
+++ b/lib/java/transform/imports.ts
@@ -15,20 +15,14 @@
  */
 
 import { Java9FileParser } from "@atomist/antlr";
-import {
-    astUtils,
-    logger,
-    Project,
-} from "@atomist/automation-client";
+import { astUtils, logger, Project, } from "@atomist/automation-client";
 import { CodeTransform } from "@atomist/sdm";
 import * as _ from "lodash";
-import {
-    countTill,
-    insertAt,
-} from "../../util/formatUtils";
+import { countTill, insertAt } from "../../util/formatUtils";
 import { classNameFromFqn } from "../javaProjectUtils";
 import { JavaImports } from "../query/javaPathExpressions";
 import { packageInfo } from "../query/packageInfo";
+import { evaluateScalar } from "@atomist/tree-path";
 
 export interface Import {
 
@@ -48,7 +42,7 @@ export interface Import {
  */
 export async function existingImports(p: Project, path: string): Promise<Import[]> {
     return astUtils.gatherFromMatches(p, Java9FileParser, path, JavaImports, m => {
-        const fqnChild = m.$children.find(c => c.$name === "qualifiedName");
+        const fqnChild = evaluateScalar(m, "//typeName");
         return {
             fqn: fqnChild.$value,
             offset: m.$offset,

--- a/lib/java/transform/imports.ts
+++ b/lib/java/transform/imports.ts
@@ -112,7 +112,7 @@ export function removeUnusedImports(opts: {
                     // Don't touch .* imports, we can't figure it out
                     return;
                 }
-                const fqnChild = m.$children.find(c => c.$name === "qualifiedName");
+                const fqnChild = evaluateScalar(m, "//typeName");
                 const simpleName = classNameFromFqn(fqnChild.$value);
 
                 // Look in the remainder of the file

--- a/lib/java/transform/imports.ts
+++ b/lib/java/transform/imports.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { JavaFileParser } from "@atomist/antlr";
+import { Java9FileParser } from "@atomist/antlr";
 import {
     astUtils,
     logger,
@@ -47,7 +47,7 @@ export interface Import {
  * @return {Promise<Import[]>}
  */
 export async function existingImports(p: Project, path: string): Promise<Import[]> {
-    return astUtils.gatherFromMatches(p, JavaFileParser, path, JavaImports, m => {
+    return astUtils.gatherFromMatches(p, Java9FileParser, path, JavaImports, m => {
         const fqnChild = m.$children.find(c => c.$name === "qualifiedName");
         return {
             fqn: fqnChild.$value,
@@ -113,7 +113,7 @@ export function removeUnusedImports(opts: {
         const file = await p.getFile(opts.sourceFilePath);
         if (!!file) {
             const source = await file.getContent();
-            return astUtils.doWithAllMatches(p, JavaFileParser, opts.sourceFilePath, JavaImports, m => {
+            return astUtils.doWithAllMatches(p, Java9FileParser, opts.sourceFilePath, JavaImports, m => {
                 if (m.$value.includes(".*")) {
                     // Don't touch .* imports, we can't figure it out
                     return;

--- a/lib/spring/generate/SpringBootProjectStructure.ts
+++ b/lib/spring/generate/SpringBootProjectStructure.ts
@@ -80,9 +80,9 @@ export class SpringBootProjectStructure {
     }
 
     private static async inferFromSourceWithJavaLikeImports(p: ProjectAsync,
-        parserOrRegistry: FileParser | FileParserRegistry,
-        globPattern: string,
-        pathExpression: string | PathExpression): Promise<SpringBootProjectStructure> {
+                                                            parserOrRegistry: FileParser | FileParserRegistry,
+                                                            globPattern: string,
+                                                            pathExpression: string | PathExpression): Promise<SpringBootProjectStructure> {
         const fileHits = await astUtils.findFileMatches(p, parserOrRegistry, globPattern, pathExpression);
         if (fileHits.length === 0) {
             return undefined;
@@ -121,8 +121,8 @@ export class SpringBootProjectStructure {
      * @param appClassFile path to the file containing the @SpringBootApplication annotation
      */
     private constructor(public readonly applicationPackage: string,
-        public readonly applicationClass: string,
-        public readonly appClassFile: ProjectFile) {
+                        public readonly applicationClass: string,
+                        public readonly appClassFile: ProjectFile) {
     }
 
 }

--- a/lib/spring/generate/SpringBootProjectStructure.ts
+++ b/lib/spring/generate/SpringBootProjectStructure.ts
@@ -15,7 +15,7 @@
  */
 
 import {
-    JavaFileParser,
+    Java9FileParser,
     KotlinFileParser,
 } from "@atomist/antlr";
 import {
@@ -68,7 +68,7 @@ export class SpringBootProjectStructure {
      * @return {Promise<SpringBootProjectStructure>}
      */
     public static async inferFromJavaSource(p: ProjectAsync): Promise<SpringBootProjectStructure> {
-        return this.inferFromSourceWithJavaLikeImports(p, JavaFileParser, JavaSourceFiles, SpringBootAppClassInJava);
+        return this.inferFromSourceWithJavaLikeImports(p, Java9FileParser, JavaSourceFiles, SpringBootAppClassInJava);
     }
 
     public static async inferFromKotlinSource(p: ProjectAsync): Promise<SpringBootProjectStructure> {
@@ -80,9 +80,9 @@ export class SpringBootProjectStructure {
     }
 
     private static async inferFromSourceWithJavaLikeImports(p: ProjectAsync,
-                                                            parserOrRegistry: FileParser | FileParserRegistry,
-                                                            globPattern: string,
-                                                            pathExpression: string | PathExpression): Promise<SpringBootProjectStructure> {
+        parserOrRegistry: FileParser | FileParserRegistry,
+        globPattern: string,
+        pathExpression: string | PathExpression): Promise<SpringBootProjectStructure> {
         const fileHits = await astUtils.findFileMatches(p, parserOrRegistry, globPattern, pathExpression);
         if (fileHits.length === 0) {
             return undefined;
@@ -95,8 +95,8 @@ export class SpringBootProjectStructure {
         // It's in the default package if no match found
         const packageName: { name: string } = {
             name: evaluateScalarValue(fh.fileNode, JavaPackageName) ||
-            evaluateScalarValue(fh.fileNode, KotlinPackage) ||
-            "",
+                evaluateScalarValue(fh.fileNode, KotlinPackage) ||
+                "",
         };
         const appClass = fh.matches[0].$value;
         if (packageName && appClass) {
@@ -121,8 +121,8 @@ export class SpringBootProjectStructure {
      * @param appClassFile path to the file containing the @SpringBootApplication annotation
      */
     private constructor(public readonly applicationPackage: string,
-                        public readonly applicationClass: string,
-                        public readonly appClassFile: ProjectFile) {
+        public readonly applicationClass: string,
+        public readonly appClassFile: ProjectFile) {
     }
 
 }

--- a/lib/spring/generate/SpringBootProjectStructure.ts
+++ b/lib/spring/generate/SpringBootProjectStructure.ts
@@ -18,7 +18,7 @@ import { Java9FileParser, KotlinFileParser } from "@atomist/antlr";
 import { astUtils, FileParser, FileParserRegistry, logger, Project, ProjectFile } from "@atomist/automation-client";
 import { evaluateScalarValue, PathExpression } from "@atomist/tree-path";
 import { KotlinPackage } from "../../java/JavaProjectStructure";
-import { JavaSourceFiles, KotlinSourceFiles, } from "../../java/javaProjectUtils";
+import { JavaSourceFiles, KotlinSourceFiles } from "../../java/javaProjectUtils";
 import { packageInfo } from "../../java/query/packageInfo";
 
 /**

--- a/lib/spring/generate/SpringBootProjectStructure.ts
+++ b/lib/spring/generate/SpringBootProjectStructure.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Java9FileParser, KotlinFileParser, } from "@atomist/antlr";
-import { astUtils, FileParser, FileParserRegistry, logger, Project, ProjectAsync, ProjectFile, } from "@atomist/automation-client";
-import { evaluateScalarValue, PathExpression, } from "@atomist/tree-path";
+import { Java9FileParser, KotlinFileParser } from "@atomist/antlr";
+import { astUtils, FileParser, FileParserRegistry, logger, Project, ProjectFile } from "@atomist/automation-client";
+import { evaluateScalarValue, PathExpression } from "@atomist/tree-path";
 import { KotlinPackage } from "../../java/JavaProjectStructure";
 import { JavaSourceFiles, KotlinSourceFiles, } from "../../java/javaProjectUtils";
 import { packageInfo } from "../../java/query/packageInfo";
@@ -51,15 +51,15 @@ export class SpringBootProjectStructure {
      * @param {ProjectAsync} p
      * @return {Promise<SpringBootProjectStructure>}
      */
-    public static async inferFromJavaSource(p: ProjectAsync): Promise<SpringBootProjectStructure> {
+    public static async inferFromJavaSource(p: Project): Promise<SpringBootProjectStructure> {
         return this.inferFromSourceWithJavaLikeImports(p, Java9FileParser, JavaSourceFiles, SpringBootAppClassInJava);
     }
 
-    public static async inferFromKotlinSource(p: ProjectAsync): Promise<SpringBootProjectStructure> {
+    public static async inferFromKotlinSource(p: Project): Promise<SpringBootProjectStructure> {
         return this.inferFromSourceWithJavaLikeImports(p, KotlinFileParser, KotlinSourceFiles, SpringBootAppClassInKotlin);
     }
 
-    public static async inferFromJavaOrKotlinSource(p: ProjectAsync): Promise<SpringBootProjectStructure> {
+    public static async inferFromJavaOrKotlinSource(p: Project): Promise<SpringBootProjectStructure> {
         return await this.inferFromJavaSource(p) || this.inferFromKotlinSource(p);
     }
 

--- a/lib/spring/generate/SpringBootProjectStructure.ts
+++ b/lib/spring/generate/SpringBootProjectStructure.ts
@@ -15,10 +15,23 @@
  */
 
 import { Java9FileParser, KotlinFileParser } from "@atomist/antlr";
-import { astUtils, FileParser, FileParserRegistry, logger, Project, ProjectFile } from "@atomist/automation-client";
-import { evaluateScalarValue, PathExpression } from "@atomist/tree-path";
+import {
+    astUtils,
+    FileParser,
+    FileParserRegistry,
+    logger,
+    Project,
+    ProjectFile,
+} from "@atomist/automation-client";
+import {
+    evaluateScalarValue,
+    PathExpression,
+} from "@atomist/tree-path";
 import { KotlinPackage } from "../../java/JavaProjectStructure";
-import { JavaSourceFiles, KotlinSourceFiles } from "../../java/javaProjectUtils";
+import {
+    JavaSourceFiles,
+    KotlinSourceFiles,
+} from "../../java/javaProjectUtils";
 import { packageInfo } from "../../java/query/packageInfo";
 
 /**

--- a/lib/spring/generate/SpringBootProjectStructure.ts
+++ b/lib/spring/generate/SpringBootProjectStructure.ts
@@ -42,9 +42,9 @@ import { JavaPackageName } from "../../java/query/javaPathExpressions";
  * Uses Java formal grammar.
  * @type {string}
  */
-export const SpringBootAppClassInJava = `//typeDeclaration
+export const SpringBootAppClassInJava = `//normalClassDeclaration
                                 [//annotation[@value='@SpringBootApplication']]
-                                /classDeclaration//Identifier`;
+                                /identifier`;
 
 /**
  * Path expression for a class name annotated with Spring Boot.

--- a/lib/spring/review/findNonSpecificMvcAnnotations.ts
+++ b/lib/spring/review/findNonSpecificMvcAnnotations.ts
@@ -41,7 +41,7 @@ export class NonSpecificMvcAnnotation implements ReviewComment {
     }
 }
 
-const RequestMappingAnnotation = `//annotation[//annotationName[@value='RequestMapping']]`;
+const RequestMappingAnnotation = `//annotation[//typeName[@value='RequestMapping']]`;
 
 /**
  * Find all non specific, old style @RequestMapping annotations

--- a/lib/spring/review/findNonSpecificMvcAnnotations.ts
+++ b/lib/spring/review/findNonSpecificMvcAnnotations.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { JavaFileParser } from "@atomist/antlr";
+import { Java9FileParser } from "@atomist/antlr";
 import {
     astUtils,
     Project,
@@ -52,7 +52,7 @@ const RequestMappingAnnotation = `//annotation[//annotationName[@value='RequestM
 export async function findNonSpecificMvcAnnotations(p: Project, globPattern: string = JavaSourceFiles): Promise<ProjectReview> {
     return {
         repoId: p.id,
-        comments: await astUtils.gatherFromMatches(p, JavaFileParser, globPattern, RequestMappingAnnotation,
+        comments: await astUtils.gatherFromMatches(p, Java9FileParser, globPattern, RequestMappingAnnotation,
             m => new NonSpecificMvcAnnotation(
                 m.$value,
                 m.sourceLocation)),

--- a/lib/spring/review/mutableInjectionsReviewer.ts
+++ b/lib/spring/review/mutableInjectionsReviewer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { JavaFileParser } from "@atomist/antlr";
+import { Java9FileParser } from "@atomist/antlr";
 import {
     astUtils,
     Project,
@@ -36,7 +36,7 @@ export class MutableInjection implements ReviewComment {
     public subcategory: string = MutableInjectionCategory;
 
     constructor(public name: string, public type: "field" | "setter",
-                public sourceLocation: SourceLocation) {
+        public sourceLocation: SourceLocation) {
     }
 
     get detail() {
@@ -64,7 +64,7 @@ const InjectedFields = `//classBodyDeclaration[//annotation[@value='@Autowired']
  * location of source tree.
  */
 export async function findMutableInjections(p: Project, globPattern: string = JavaSourceFiles): Promise<ProjectReview> {
-    const fileHits = await astUtils.findMatches(p, JavaFileParser, globPattern, InjectedFields);
+    const fileHits = await astUtils.findMatches(p, Java9FileParser, globPattern, InjectedFields);
     const comments = fileHits.map(m => new MutableInjection(
         m.$value,
         m.$value.startsWith("set") ? "setter" : "field",

--- a/lib/spring/review/mutableInjectionsReviewer.ts
+++ b/lib/spring/review/mutableInjectionsReviewer.ts
@@ -36,7 +36,7 @@ export class MutableInjection implements ReviewComment {
     public subcategory: string = MutableInjectionCategory;
 
     constructor(public name: string, public type: "field" | "setter",
-        public sourceLocation: SourceLocation) {
+                public sourceLocation: SourceLocation) {
     }
 
     get detail() {

--- a/lib/spring/review/mutableInjectionsReviewer.ts
+++ b/lib/spring/review/mutableInjectionsReviewer.ts
@@ -51,9 +51,9 @@ const InjectedFields = `//classBodyDeclaration[//annotation[@value='@Autowired']
                          //classBodyDeclaration[//annotation[@value='@Inject']]
                             //fieldDeclaration//variableDeclaratorId |
                          //classBodyDeclaration[//annotation[@value='@Autowired']]
-                            //methodDeclaration//Identifier[1] |
+                            //methodDeclaration//methodDeclarator/identifier |
                          //classBodyDeclaration[//annotation[@value='@Inject']]
-                            //methodDeclaration//Identifier[1]`;
+                            //methodDeclaration//methodDeclarator/identifier`;
 
 /**
  * Find all fields or setters annotated with @Autowired or @Inject in the codebase.

--- a/lib/spring/transform/removeUnnecessaryAutowiredAnnotations.ts
+++ b/lib/spring/transform/removeUnnecessaryAutowiredAnnotations.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { JavaFileParser } from "@atomist/antlr";
+import { Java9FileParser } from "@atomist/antlr";
 import {
     astUtils,
 } from "@atomist/automation-client";
@@ -34,9 +34,9 @@ const Constructors = `//classBodyDeclaration[//constructorDeclaration]`;
  * @return {Promise<void>}
  */
 export const removeAutowiredOnSoleConstructor: CodeTransform = async p => {
-    const constructors = await astUtils.findMatches(p, JavaFileParser, JavaSourceFiles, Constructors);
+    const constructors = await astUtils.findMatches(p, Java9FileParser, JavaSourceFiles, Constructors);
     if (constructors.length === 1 && constructors[0].$value.includes("@Autowired")) {
-        await astUtils.doWithAllMatches(p, JavaFileParser, JavaSourceFiles, Constructors, constructor =>
+        await astUtils.doWithAllMatches(p, Java9FileParser, JavaSourceFiles, Constructors, constructor =>
             constructor.$value = constructor.$value.replace(/@Autowired[\s]+/, ""));
     }
 };

--- a/lib/spring/transform/removeUnnecessaryComponentScanAnnotations.ts
+++ b/lib/spring/transform/removeUnnecessaryComponentScanAnnotations.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { JavaFileParser } from "@atomist/antlr";
+import { Java9FileParser } from "@atomist/antlr";
 import {
     astUtils,
     ProjectReview,
@@ -40,7 +40,7 @@ const UnnecessaryComponentScanAnnotations = `//typeDeclaration[/classDeclaration
                             //annotation[@value='@ComponentScan']`;
 
 export const removeUnnecessaryComponentScanTransform: CodeTransform = p => {
-    return astUtils.zapAllMatches(p, JavaFileParser, JavaSourceFiles,
+    return astUtils.zapAllMatches(p, Java9FileParser, JavaSourceFiles,
         UnnecessaryComponentScanAnnotations,
         ZapTrailingWhitespace);
 };
@@ -48,27 +48,27 @@ export const removeUnnecessaryComponentScanTransform: CodeTransform = p => {
 export const UnnecessaryComponentScanCategory = "unnecessary annotations";
 
 export const unnecessaryComponentScanReviewer: CodeInspection<ProjectReview> = async p => {
-        const matches = await astUtils.findMatches(p, JavaFileParser, JavaSourceFiles, UnnecessaryComponentScanAnnotations);
-        return {
-            repoId: p.id,
-            comments: matches.map(m => {
-                return {
-                    severity: "info" as Severity,
-                    category: SpringStyle,
-                    subcategory: UnnecessaryComponentScanCategory,
-                    detail: "`@ComponentScan` annotations are not necessary on `@SpringBootApplication` classes as they are inherited",
-                    sourceLocation: m.sourceLocation,
-                    fix: {
-                        command: "RemoveUnnecessaryComponentScanAnnotations",
-                        params: {
-                            "target.owner": p.id.owner,
-                            "target.repo": p.id.repo,
-                        },
+    const matches = await astUtils.findMatches(p, Java9FileParser, JavaSourceFiles, UnnecessaryComponentScanAnnotations);
+    return {
+        repoId: p.id,
+        comments: matches.map(m => {
+            return {
+                severity: "info" as Severity,
+                category: SpringStyle,
+                subcategory: UnnecessaryComponentScanCategory,
+                detail: "`@ComponentScan` annotations are not necessary on `@SpringBootApplication` classes as they are inherited",
+                sourceLocation: m.sourceLocation,
+                fix: {
+                    command: "RemoveUnnecessaryComponentScanAnnotations",
+                    params: {
+                        "target.owner": p.id.owner,
+                        "target.repo": p.id.repo,
                     },
-                };
-            }),
-        };
+                },
+            };
+        }),
     };
+};
 
 export const UnnecessaryComponentScanReviewer: ReviewerRegistration = {
     name: "unnecessary-component-scan-reviewer",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,12 +49,13 @@
       }
     },
     "@atomist/antlr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@atomist/antlr/-/antlr-1.0.1.tgz",
-      "integrity": "sha512-fs9XHkJV2XewUjJ9YwtYAe89158gS+eiIRs22AypZk8g/O9XgHiDKw275drcOy9u+QUn+YeVW/fxV4ejfKJgCA==",
+      "version": "1.0.2-java9.20181219033844",
+      "resolved": "https://registry.npmjs.org/@atomist/antlr/-/antlr-1.0.2-java9.20181219033844.tgz",
+      "integrity": "sha512-JPKLu8uGDLHX9rs82ofrKdSx/ANJBdRvZ1dcovYfJEcXvimuueNb0Bu2jRIxbH2HA/hEIN1JOigDg5/WW9xsNA==",
       "requires": {
+        "@jessitron/antlr4ts": "0.4.0-dev",
         "@types/lodash": "^4.14.118",
-        "antlr4ts": "^0.4.1-alpha.0",
+        "antlr4ts": "^0.5.0-alpha.1",
         "lodash": "^4.17.10"
       }
     },
@@ -371,6 +372,11 @@
         "supports-color": "^5.5.0",
         "tslib": "^1.9.3"
       }
+    },
+    "@jessitron/antlr4ts": {
+      "version": "0.4.0-dev",
+      "resolved": "https://registry.npmjs.org/@jessitron/antlr4ts/-/antlr4ts-0.4.0-dev.tgz",
+      "integrity": "sha512-cQgddEKLDdJjc5Pxp+Ptmy8X8lxsenyI2F/0UvxrFTYufF3egwwRIlmhm2KFmob/JxB+NoU0BXtPFieBBBU0/w=="
     },
     "@oclif/color": {
       "version": "0.0.0",
@@ -1363,9 +1369,9 @@
       "dev": true
     },
     "antlr4ts": {
-      "version": "0.4.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.4.1-alpha.0.tgz",
-      "integrity": "sha1-rFcX8w8++jYXsATo/0+GC5x9TSA="
+      "version": "0.5.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.1.tgz",
+      "integrity": "sha512-LU5FLWq2fUwg2cTL/DeIL16ucUm5jv6SNVFoMjbYLviXAp6p5g1ZzkTAnWiOKX/muEEy0PY78perPj6WUBSQCw=="
     },
     "any-observable": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "dependencies": {
-    "@atomist/antlr": "^1.0.1",
+    "@atomist/antlr": "^1.0.2-java9.20181219033844",
     "@atomist/microgrammar": "^1.0.1",
-    "@atomist/tree-path": "^1.0.1",
     "@atomist/sdm-pack-build": "^1.0.3",
+    "@atomist/tree-path": "^1.0.1",
     "@types/cross-spawn": "^6.0.0",
     "@types/dateformat": "^1.0.1",
     "@types/decompress": "^4.2.3",
@@ -42,10 +42,10 @@
     "decompress": "^4.2.0",
     "lodash": "^4.17.10",
     "portfinder": "^1.0.13",
+    "prettify-xml": "^1.2.0",
     "tmp-promise": "^1.0.5",
     "toml": "^2.3.3",
-    "xmldoc": "^1.1.2",
-    "prettify-xml": "^1.2.0"
+    "xmldoc": "^1.1.2"
   },
   "peerDependencies": {
     "@atomist/automation-client": ">=1.1.0",

--- a/test/spring/generator/SpringBootProjectStructure.test.ts
+++ b/test/spring/generator/SpringBootProjectStructure.test.ts
@@ -57,6 +57,14 @@ describe("SpringBootProjectStructure: Java inference", () => {
             assert(structure.appClassFile.path === GishJavaPath);
         });
 
+        it("infer application package and class when present using lambda", async () => {
+            const structure = await SpringBootProjectStructure.inferFromJavaSource(GishProjectWithLambda());
+            assert(structure.applicationPackage === "com.smashing.pumpkins");
+            assert(structure.applicationClass === "GishApplication",
+                `Expected name not to be ${structure.appClassFile.name}`);
+            assert(structure.appClassFile.path === GishJavaPath);
+        });
+
         it("infer application package and class when present, ignoring extraneous comment", async () => {
             const structure = await SpringBootProjectStructure.inferFromJavaSource(GishProjectWithComment());
             assert(structure.applicationPackage === "com.smashing.pumpkins");
@@ -124,6 +132,7 @@ const javaSource =
 
 @SpringBootApplication
 class GishApplication {
+    //1
 }
 
 `;
@@ -166,6 +175,18 @@ export const GishProject: () => Project = () => InMemoryProject.from(
     {
         path: GishJavaPath,
         content: javaSource,
+    }, {
+        path: "pom.xml",
+        content: SimplePom,
+    },
+);
+
+export const GishProjectWithLambda: () => Project = () => InMemoryProject.from(
+    { owner: "smashing-pumpkins", repo: "gish", url: "" },
+    {
+        path: GishJavaPath,
+        content: javaSource.replace("//1", `NumericTest isEven = (n) -> (n % 2) == 0;
+	NumericTest isNegative = (n) -> (n < 0);`),
     }, {
         path: "pom.xml",
         content: SimplePom,

--- a/test/spring/generator/SpringBootProjectStructure.test.ts
+++ b/test/spring/generator/SpringBootProjectStructure.test.ts
@@ -65,6 +65,14 @@ describe("SpringBootProjectStructure: Java inference", () => {
             assert(structure.appClassFile.path === GishJavaPath);
         });
 
+        it("infer application package and class when present using local type inference", async () => {
+            const structure = await SpringBootProjectStructure.inferFromJavaSource(GishProjectWithLocalTypeInference());
+            assert(structure.applicationPackage === "com.smashing.pumpkins");
+            assert(structure.applicationClass === "GishApplication",
+                `Expected name not to be ${structure.appClassFile.name}`);
+            assert(structure.appClassFile.path === GishJavaPath);
+        });
+
         it("infer application package and class when present, ignoring extraneous comment", async () => {
             const structure = await SpringBootProjectStructure.inferFromJavaSource(GishProjectWithComment());
             assert(structure.applicationPackage === "com.smashing.pumpkins");
@@ -187,6 +195,17 @@ export const GishProjectWithLambda: () => Project = () => InMemoryProject.from(
         path: GishJavaPath,
         content: javaSource.replace("//1", `NumericTest isEven = (n) -> (n % 2) == 0;
 	NumericTest isNegative = (n) -> (n < 0);`),
+    }, {
+        path: "pom.xml",
+        content: SimplePom,
+    },
+);
+
+export const GishProjectWithLocalTypeInference: () => Project = () => InMemoryProject.from(
+    { owner: "smashing-pumpkins", repo: "gish", url: "" },
+    {
+        path: GishJavaPath,
+        content: javaSource.replace("//1", "var x = new HashMap<String,Integer>();"),
     }, {
         path: "pom.xml",
         content: SimplePom,


### PR DESCRIPTION
Updates to most recent ANTLR grammar for Java. 

The Java language spec has changed so many productions have different names. Hence many updates were needed to code in this pack.