### PR TITLE
Change project inference interface

### DIFF
--- a/lib/spring/generate/SpringBootProjectStructure.ts
+++ b/lib/spring/generate/SpringBootProjectStructure.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import {
     evaluateScalarValue,
     PathExpression,
 } from "@atomist/tree-path";
+import * as path from "path";
 import { KotlinPackage } from "../../java/JavaProjectStructure";
 import {
     JavaSourceFiles,
@@ -64,12 +65,12 @@ export class SpringBootProjectStructure {
      * @param {ProjectAsync} p
      * @return {Promise<SpringBootProjectStructure>}
      */
-    public static async inferFromJavaSource(p: Project): Promise<SpringBootProjectStructure> {
-        return this.inferFromSourceWithJavaLikeImports(p, Java9FileParser, JavaSourceFiles, SpringBootAppClassInJava);
+    public static async inferFromJavaSource(p: Project, globOptions: string | string[] = JavaSourceFiles): Promise<SpringBootProjectStructure> {
+        return this.inferFromSourceWithJavaLikeImports(p, Java9FileParser, globOptions, SpringBootAppClassInJava);
     }
 
-    public static async inferFromKotlinSource(p: Project): Promise<SpringBootProjectStructure> {
-        return this.inferFromSourceWithJavaLikeImports(p, KotlinFileParser, KotlinSourceFiles, SpringBootAppClassInKotlin);
+    public static async inferFromKotlinSource(p: Project, globOptions: string | string[] = KotlinSourceFiles): Promise<SpringBootProjectStructure> {
+        return this.inferFromSourceWithJavaLikeImports(p, KotlinFileParser, globOptions, SpringBootAppClassInKotlin);
     }
 
     public static async inferFromJavaOrKotlinSource(p: Project): Promise<SpringBootProjectStructure> {
@@ -78,14 +79,17 @@ export class SpringBootProjectStructure {
 
     private static async inferFromSourceWithJavaLikeImports(p: Project,
                                                             parserOrRegistry: FileParser | FileParserRegistry,
-                                                            globPattern: string,
+                                                            globOptions: string | string[],
                                                             pathExpression: string | PathExpression): Promise<SpringBootProjectStructure> {
-        const fileHits = await astUtils.findFileMatches(p, parserOrRegistry, globPattern, pathExpression);
+        const fileHits = await astUtils.findFileMatches(p, parserOrRegistry, globOptions, pathExpression);
         if (fileHits.length === 0) {
             return undefined;
         }
         if (fileHits.length > 1) {
-            return undefined;
+            const msg = `Found more than one Spring Boot application annotation in files: ` +
+                fileHits.map(f => path.join(f.file.path, f.file.name)).join(",");
+            logger.warn(msg);
+            throw new Error(msg);
         }
         const fh = fileHits[0];
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,1 +1,0 @@
-declare module "prettify-xml";

--- a/lib/typings/prettify-xml.ts
+++ b/lib/typings/prettify-xml.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare module "prettify-xml";

--- a/test/spring/generator/springProjects.ts
+++ b/test/spring/generator/springProjects.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    InMemoryProject,
+    Project,
+} from "@atomist/automation-client";
+
+export const javaSource =
+    `package com.smashing.pumpkins;
+
+@SpringBootApplication
+class GishApplication {
+    //1
+}
+
+`;
+
+export const kotlinSource =
+    `package com.smashing.pumpkins
+
+@SpringBootApplication
+class GishApplication {
+}
+
+`;
+
+const SimplePom = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>flux-flix-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>flux-flix-service</name>
+    <description>Demo project for Spring Boot</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.0.0.BUILD-SNAPSHOT</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+</project>
+`;
+
+export const GishJavaPath = "src/main/java/com/smashing/pumpkins/Gish.java";
+
+export const GishProject: () => Project = () => InMemoryProject.from(
+    { owner: "smashing-pumpkins", repo: "gish", url: "" },
+    {
+        path: GishJavaPath,
+        content: javaSource,
+    }, {
+        path: "pom.xml",
+        content: SimplePom,
+    },
+);
+
+export const GishProjectWithLambda: () => Project = () => InMemoryProject.from(
+    { owner: "smashing-pumpkins", repo: "gish", url: "" },
+    {
+        path: GishJavaPath,
+        content: javaSource.replace("//1", `NumericTest isEven = (n) -> (n % 2) == 0;
+	NumericTest isNegative = (n) -> (n < 0);`),
+    }, {
+        path: "pom.xml",
+        content: SimplePom,
+    },
+);
+
+export const GishProjectWithLocalTypeInference: () => Project = () => InMemoryProject.from(
+    { owner: "smashing-pumpkins", repo: "gish", url: "" },
+    {
+        path: GishJavaPath,
+        content: javaSource.replace("//1", "var x = new HashMap<String,Integer>();"),
+    }, {
+        path: "pom.xml",
+        content: SimplePom,
+    },
+);
+
+export const GishProjectWithComment: () => Project = () => InMemoryProject.from(
+    { owner: "smashing-pumpkins", repo: "gish", url: "" },
+    {
+        path: GishJavaPath,
+        content: javaSource.replace("@SpringBootApplication", "@SpringBootApplication // ha ha trying to fool you"),
+    }, {
+        path: "pom.xml",
+        content: SimplePom,
+    },
+);
+
+export const GishKotlinPath = "src/main/kotlin/com/smashing/pumpkins/Gish.kt";
+
+export const KotlinGishProject: () => Project = () => InMemoryProject.from(
+    { owner: "smashing-pumpkins", repo: "gish", url: "" },
+    {
+        path: GishKotlinPath,
+        content: kotlinSource,
+    }, {
+        path: "pom.xml",
+        content: SimplePom,
+    },
+);
+
+export const ProblemProject: () => Project = () => InMemoryProject.from(
+    { owner: "smashing-pumpkins", repo: "gish", url: "" },
+    {
+        path: "src/main/java/com/av/AardvarkApplication.java",
+        content: ProblemFile1,
+    }, {
+        path: "pom.xml",
+        content: SimplePom,
+    },
+);
+
+const ProblemFile1 = `
+package com.av;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AardvarkApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run
+	}
+}
+`;

--- a/test/spring/transform/addAnnotationToSpringBootClass.test.ts
+++ b/test/spring/transform/addAnnotationToSpringBootClass.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import { addAnnotationToSpringBootClass } from "../../../lib/spring/transform/ad
 import {
     GishJavaPath,
     GishProject,
-} from "../generator/SpringBootProjectStructure.test";
+} from "../generator/springProjects";
 
 describe("addAnnotationToSpringBootClass", () => {
 


### PR DESCRIPTION
Accept glob patterns when inferring projects so certain patterns can
be excluded, e.g., when a project contains example code that is not
part of the compiled project.

Throw an exception when a project has more than one Spring Boot
application annotation instead of silently ignoring it.

Move reused exports from the Spring Boot project structure tests to
another file so those tests do not get run twice.